### PR TITLE
ensure that AzBI module is runnable via cli

### DIFF
--- a/cmd/az-sp-create.go
+++ b/cmd/az-sp-create.go
@@ -74,7 +74,7 @@ func init() {
 
 	createCmd.Flags().String("tenantID", "", "TenantID of AAD where service principal should be created")
 	createCmd.Flags().String("subscriptionID", "", "SubscriptionID of subscription where service principal should have access")
-	createCmd.Flags().String("newServicePrincipalName", "epiphany-cli", "Display Name of service principal")
+	createCmd.Flags().String("name", "epiphany-cli", "Display Name of service principal")
 }
 
 func isEnvPresentAndSelected() (config *configuration.Config, err error) {

--- a/cmd/az-sp-create.go
+++ b/cmd/az-sp-create.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
-
 	"github.com/epiphany-platform/cli/pkg/az"
 	"github.com/epiphany-platform/cli/pkg/configuration"
 	"github.com/epiphany-platform/cli/pkg/environment"
@@ -74,9 +72,9 @@ var createCmd = &cobra.Command{
 func init() {
 	spCmd.AddCommand(createCmd)
 
-	createCmd.Flags().String("tenantID", "", fmt.Sprintf("TenantID of AAD where Service Principal should be created"))
-	createCmd.Flags().String("subscriptionID", "", fmt.Sprintf("SubsciptionID of Subscription where Service Principal should have access"))
-	createCmd.Flags().String("name", "epiphany-cli", fmt.Sprintf("Display Name of Service Principal"))
+	createCmd.Flags().String("tenantID", "", "TenantID of AAD where service principal should be created")
+	createCmd.Flags().String("subscriptionID", "", "SubscriptionID of subscription where service principal should have access")
+	createCmd.Flags().String("name", "epiphany-cli", "Display Name of service principal")
 }
 
 func isEnvPresentAndSelected() (config *configuration.Config, err error) {

--- a/cmd/az-sp-create.go
+++ b/cmd/az-sp-create.go
@@ -15,8 +15,8 @@ var (
 	newServicePrincipalName string
 )
 
-// createCmd represents the create command
-var createCmd = &cobra.Command{
+// azSpCreateCmd represents the create command
+var azSpCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create Service Principal",
 	Long:  `Create Service Principal that can be used for authentication with Azure.`,
@@ -70,11 +70,11 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
-	spCmd.AddCommand(createCmd)
+	spCmd.AddCommand(azSpCreateCmd)
 
-	createCmd.Flags().String("tenantID", "", "TenantID of AAD where service principal should be created")
-	createCmd.Flags().String("subscriptionID", "", "SubscriptionID of subscription where service principal should have access")
-	createCmd.Flags().String("name", "epiphany-cli", "Display Name of service principal")
+	azSpCreateCmd.Flags().String("tenantID", "", "TenantID of AAD where service principal should be created")
+	azSpCreateCmd.Flags().String("subscriptionID", "", "SubscriptionID of subscription where service principal should have access")
+	azSpCreateCmd.Flags().String("name", "epiphany-cli", "Display Name of service principal")
 }
 
 func isEnvPresentAndSelected() (config *configuration.Config, err error) {

--- a/cmd/az-sp-create.go
+++ b/cmd/az-sp-create.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	tenantID       string
-	subscriptionID string
-	name           string
+	tenantID                string
+	subscriptionID          string
+	newServicePrincipalName string
 )
 
 // createCmd represents the create command
@@ -30,7 +30,7 @@ var createCmd = &cobra.Command{
 
 		tenantID = viper.GetString("tenantID")
 		subscriptionID = viper.GetString("subscriptionID")
-		name = viper.GetString("name")
+		newServicePrincipalName = viper.GetString("name")
 
 		if tenantID == "" {
 			//TODO get default tenant
@@ -50,7 +50,7 @@ var createCmd = &cobra.Command{
 		if err != nil {
 			logger.Fatal().Err(err).Msg("failed to generate password")
 		}
-		app, _, err := az.CreateServicePrincipal(pass, subscriptionID, tenantID, name)
+		app, _, err := az.CreateServicePrincipal(pass, subscriptionID, tenantID, newServicePrincipalName)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("creation of service principal on Azure failed")
 		}
@@ -74,7 +74,7 @@ func init() {
 
 	createCmd.Flags().String("tenantID", "", "TenantID of AAD where service principal should be created")
 	createCmd.Flags().String("subscriptionID", "", "SubscriptionID of subscription where service principal should have access")
-	createCmd.Flags().String("name", "epiphany-cli", "Display Name of service principal")
+	createCmd.Flags().String("newServicePrincipalName", "epiphany-cli", "Display Name of service principal")
 }
 
 func isEnvPresentAndSelected() (config *configuration.Config, err error) {

--- a/cmd/az.go
+++ b/cmd/az.go
@@ -7,7 +7,7 @@ import (
 // azCmd represents the az command
 var azCmd = &cobra.Command{
 	Use:   "az",
-	Short: "Commands used to work with Azure cloud.",
+	Short: "Azure Cloud related operations",
 	Long:  `Commands used to work with Azure cloud.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		debug("az pre run called")

--- a/cmd/components-install.go
+++ b/cmd/components-install.go
@@ -67,7 +67,7 @@ var componentsInstallCmd = &cobra.Command{
 		if err != nil {
 			logger.Fatal().Err(err).Msg("install component in environment failed")
 		}
-		fmt.Printf("Installed component %s %s to environment %s\n", newComponent.Name, newComponent.Version, e.Name)
+		fmt.Printf("Installed component %s:%s to environment %s\n", newComponent.Name, newComponent.Version, e.Name)
 	},
 }
 

--- a/cmd/components-install.go
+++ b/cmd/components-install.go
@@ -52,6 +52,7 @@ var componentsInstallCmd = &cobra.Command{
 			Image:          c.Versions[0].Image,
 			WorkDirectory:  c.Versions[0].WorkDirectory,
 			Mounts:         c.Versions[0].Mounts,
+			Shared:         c.Versions[0].Shared,
 		}
 		for _, rc := range c.Versions[0].Commands {
 			nic := environment.InstalledComponentCommand{

--- a/cmd/environments-new.go
+++ b/cmd/environments-new.go
@@ -33,14 +33,16 @@ var environmentsNewCmd = &cobra.Command{
 		if newEnvName == "" {
 			if len(args) == 1 {
 				newEnvName = args[0]
-			} else {
-				newEnvName, err = promptui.PromptForString("Environment name")
-				if err != nil {
-					logger.Fatal().Err(err).Msg("prompt failed")
-				}
 			}
-			debug("new environment name is: %s", newEnvName)
 		}
+		if newEnvName == "" {
+			newEnvName, err = promptui.PromptForString("Environment name")
+			if err != nil {
+				logger.Fatal().Err(err).Msg("prompt failed")
+			}
+		}
+
+		debug("new environment name is: %s", newEnvName)
 
 		err = config.CreateNewEnvironment(newEnvName)
 		if err != nil {

--- a/cmd/environments-run.go
+++ b/cmd/environments-run.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"strings"
-	"text/template"
-
 	"github.com/epiphany-platform/cli/pkg/configuration"
 	"github.com/epiphany-platform/cli/pkg/environment"
+	"github.com/epiphany-platform/cli/pkg/processor"
 
 	"github.com/spf13/cobra"
 )
@@ -27,15 +24,15 @@ var environmentsRunCmd = &cobra.Command{ //TODO consider what are options to cre
 			if err != nil {
 				logger.Fatal().Err(err).Msg("get config failed")
 			}
-			e, err := environment.Get(config.CurrentEnvironment)
+			env, err := environment.Get(config.CurrentEnvironment)
 			if err != nil {
 				logger.Fatal().Err(err).Msg("get environments details failed")
 			}
-			c, err := e.GetComponentByName(args[0])
+			c, err := env.GetComponentByName(args[0])
 			if err != nil {
 				logger.Fatal().Err(err).Msg("getting component by name failed")
 			}
-			err = c.Run(args[1], environmentsProcessor(config))
+			err = c.Run(args[1], processor.TemplateProcessor(config, env))
 			if err != nil {
 				logger.Fatal().Err(err).Msg("run command failed")
 			}
@@ -51,42 +48,4 @@ var environmentsRunCmd = &cobra.Command{ //TODO consider what are options to cre
 
 func init() {
 	environmentsCmd.AddCommand(environmentsRunCmd)
-}
-
-func environmentsProcessor(config *configuration.Config) func(envs map[string]string) map[string]string {
-	return func(envs map[string]string) map[string]string {
-		result := make(map[string]string)
-		for k, v := range envs {
-			if strings.HasPrefix(v, "#") {
-				logger.Debug().Msgf("key %s has value %s", k, v)
-				parts := strings.Split(v, "#")
-				logger.Debug().Msgf("and value has parts: %#v", parts)
-				if parts[1] == "Config" {
-					t, err := template.New(k).Parse(parts[2])
-					if err != nil {
-						logger.Error().Err(err)
-						break
-					}
-					logger.Debug().Msgf("parsed template: %#v", t)
-					var b bytes.Buffer
-					err = t.Execute(&b, config)
-					if err != nil {
-						logger.Error().Err(err)
-						break
-					}
-					r := b.String()
-					if r == "" {
-						logger.Error().Err(errors.New("there was no value obtained"))
-						break
-					}
-					logger.Debug().Msgf("result value: %#v", b.String())
-					result[k] = b.String()
-				}
-			} else {
-				result[k] = v
-			}
-		}
-
-		return result
-	}
 }

--- a/cmd/ssh-keygen-create.go
+++ b/cmd/ssh-keygen-create.go
@@ -43,5 +43,5 @@ var sshKeygenCreateCmd = &cobra.Command{
 }
 
 func init() {
-	keygenCmd.AddCommand(sshKeygenCreateCmd)
+	sshKeygenCmd.AddCommand(sshKeygenCreateCmd)
 }

--- a/cmd/ssh-keygen-create.go
+++ b/cmd/ssh-keygen-create.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/epiphany-platform/cli/pkg/auth"
+	"github.com/epiphany-platform/cli/pkg/configuration"
+	"github.com/epiphany-platform/cli/pkg/environment"
+	"github.com/epiphany-platform/cli/pkg/util"
+	"path"
+
+	"github.com/spf13/cobra"
+)
+
+// sshKeygenCreateCmd represents the create command
+var sshKeygenCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "TODO",
+	Long:  `TODO`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("create called")
+		config, err := configuration.GetConfig()
+		if err != nil {
+			logger.Fatal().Err(err).Msg("get config failed")
+		}
+		env, err := environment.Get(config.CurrentEnvironment)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("get environments details failed")
+		}
+		kp, err := auth.GenerateRsaKeyPair(path.Join(
+			util.UsedEnvironmentDirectory,
+			env.Uuid.String(),
+			"/shared", //TODO to consts
+		))
+		if err != nil {
+			logger.Fatal().Err(err).Msg("generate rsa keypair failed")
+		}
+		env.AddRsaKeyPair(kp)
+		err = env.Save()
+		if err != nil {
+			logger.Fatal().Err(err).Msg("save env failed")
+		}
+	},
+}
+
+func init() {
+	keygenCmd.AddCommand(sshKeygenCreateCmd)
+}

--- a/cmd/ssh-keygen-create.go
+++ b/cmd/ssh-keygen-create.go
@@ -14,8 +14,8 @@ import (
 // sshKeygenCreateCmd represents the create command
 var sshKeygenCreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "TODO",
-	Long:  `TODO`,
+	Short: "Create new ssh keypair in current environment.",
+	Long:  `This command creates new ssh keypair in current environment and stores information about it in environment.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("create called")
 		config, err := configuration.GetConfig()

--- a/cmd/ssh-keygen.go
+++ b/cmd/ssh-keygen.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// keygenCmd represents the keygen command
-var keygenCmd = &cobra.Command{
+// sshKeygenCmd represents the keygen command
+var sshKeygenCmd = &cobra.Command{
 	Use:   "keygen",
 	Short: "TODO",
 	Long:  `TODO`,
@@ -17,5 +17,5 @@ var keygenCmd = &cobra.Command{
 }
 
 func init() {
-	sshCmd.AddCommand(keygenCmd)
+	sshCmd.AddCommand(sshKeygenCmd)
 }

--- a/cmd/ssh-keygen.go
+++ b/cmd/ssh-keygen.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// keygenCmd represents the keygen command
+var keygenCmd = &cobra.Command{
+	Use:   "keygen",
+	Short: "TODO",
+	Long:  `TODO`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("keygen called")
+	},
+}
+
+func init() {
+	sshCmd.AddCommand(keygenCmd)
+}

--- a/cmd/ssh-keygen.go
+++ b/cmd/ssh-keygen.go
@@ -9,8 +9,8 @@ import (
 // sshKeygenCmd represents the keygen command
 var sshKeygenCmd = &cobra.Command{
 	Use:   "keygen",
-	Short: "TODO",
-	Long:  `TODO`,
+	Short: "Commands related to ssh keygen operations.",
+	Long:  `Commands related to ssh keygen operations.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("keygen called")
 	},

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -9,8 +9,8 @@ import (
 // sshCmd represents the ssh command
 var sshCmd = &cobra.Command{
 	Use:   "ssh",
-	Short: "TODO",
-	Long:  `TODO`,
+	Short: "Ssh and keys operations",
+	Long:  `Commands related to ssh and keys operations.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("ssh called")
 	},

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// sshCmd represents the ssh command
+var sshCmd = &cobra.Command{
+	Use:   "ssh",
+	Short: "TODO",
+	Long:  `TODO`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("ssh called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sshCmd)
+}

--- a/fixtures/cmd/e_components_install_want
+++ b/fixtures/cmd/e_components_install_want
@@ -1,1 +1,1 @@
-Installed component c1 0.1.0 to environment e1
+Installed component c1:0.1.0 to environment e1

--- a/fixtures/cmd/e_help_want
+++ b/fixtures/cmd/e_help_want
@@ -4,10 +4,11 @@ Usage:
   e [command]
 
 Available Commands:
-  az           Commands used to work with Azure cloud.
+  az           Azure Cloud related operations
   components   Allows to inspect and install available components
   environments Allows various interactions with environments
   help         Help about any command
+  ssh          Ssh and keys operations
 
 Flags:
       --configDir string   config directory (default is .e)

--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,9 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
+	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
 	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc // indirect
-	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	golang.org/x/sys v0.0.0-20201218084310-7d0127a74742 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.60.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 h1:3wPMTskHO3+O6jqTEXyFcsnuxMQOqYSaHsDxcbUXpqA=
+golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -364,11 +366,14 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201218084310-7d0127a74742 h1:+CBz4km/0KPU3RGTwARGh/noP3bEwtHcq+0YcBQM2JQ=
+golang.org/x/sys v0.0.0-20201218084310-7d0127a74742/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/auth/ssh.go
+++ b/pkg/auth/ssh.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"golang.org/x/crypto/ssh"
+	"io/ioutil"
+	"path"
+)
+
+const rsaKeyName = "vms_rsa"
+
+type RsaKeyPair struct {
+	Name string
+}
+
+func GenerateRsaKeyPair(directory string) (kp RsaKeyPair, err error) {
+	err = generateRsaKeyPair(directory, rsaKeyName)
+	if err != nil {
+		return
+	}
+	return RsaKeyPair{rsaKeyName}, nil
+}
+
+func generateRsaKeyPair(directory string, name string) error {
+	privateRsaKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return err
+	}
+	pemBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateRsaKey)}
+	privateKeyBytes := pem.EncodeToMemory(pemBlock)
+
+	publicRsaKey, err := ssh.NewPublicKey(&privateRsaKey.PublicKey)
+	if err != nil {
+		return err
+	}
+	publicKeyBytes := ssh.MarshalAuthorizedKey(publicRsaKey)
+
+	err = ioutil.WriteFile(path.Join(directory, name), privateKeyBytes, 0600)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(path.Join(directory, fmt.Sprintf("%s.pub", name)), publicKeyBytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/auth/ssh_test.go
+++ b/pkg/auth/ssh_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+)
+
+func TestGenerateRsaKeyPair(t *testing.T) {
+	type args struct {
+		directory string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantKp  RsaKeyPair
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				directory: "hp",
+			},
+			wantKp: RsaKeyPair{
+				Name: rsaKeyName,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+
+		dir, err := ioutil.TempDir("", tt.args.directory)
+		if err != nil {
+			t.Error(err)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			gotKp, err := GenerateRsaKeyPair(dir)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateRsaKeyPair() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotKp, tt.wantKp) {
+				t.Errorf("GenerateRsaKeyPair() gotKp = %v, want %v", gotKp, tt.wantKp)
+			}
+		})
+	}
+}
+
+func Test_generateRsaKeyPair(t *testing.T) {
+	type args struct {
+		directory string
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				directory: "hp",
+				name:      rsaKeyName,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+
+		dir, err := ioutil.TempDir("", tt.args.directory)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if err := generateRsaKeyPair(dir, tt.args.name); (err != nil) != tt.wantErr {
+				t.Errorf("generateRsaKeyPair() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -39,6 +39,11 @@ func (c *Config) CreateNewEnvironment(name string) error {
 	if err != nil {
 		errCreateEnvironment(err)
 	}
+	util.EnsureDirectory(path.Join(
+		util.UsedEnvironmentDirectory,
+		env.Uuid.String(),
+		"/shared", //TODO to consts
+	))
 	c.CurrentEnvironment = env.Uuid
 	debug("will try to save updated config %+v", c)
 	return c.Save()

--- a/pkg/configuration/ops.go
+++ b/pkg/configuration/ops.go
@@ -2,7 +2,8 @@ package configuration
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+	"os"
+	"time"
 )
 
 var (
@@ -10,10 +11,8 @@ var (
 )
 
 func init() {
-	logger = log.
-		With().
-		Str("package", "configuration").
-		Logger()
+	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	logger = zerolog.New(output).With().Str("package", "configuration").Caller().Timestamp().Logger()
 }
 
 func debug(format string, v ...interface{}) {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -173,6 +173,9 @@ func clientAndContext() (context.Context, *client.Client, error) {
 }
 
 func removeFinishedContainer(cli *client.Client, ctx context.Context, containerID string) {
+	//TODO probably add check if container is running with retry because of:
+	//Error response from daemon: You cannot remove a running container XXX. Stop the container before attempting removal or force remove
+
 	err := cli.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{})
 	if err != nil {
 		warnRemovingContainer(err)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -20,13 +20,13 @@ type Image struct {
 	Name string
 }
 
-func (i *Image) Pull() (string, error) { //TODO remove splitting log streams here, but use zerolog multiwriter
+func (image *Image) Pull() (string, error) { //TODO remove splitting log streams here, but use zerolog multiwriter
 	debug("will try to pull")
 	ctx, cli, err := clientAndContext()
 	if err != nil {
 		return "", err
 	}
-	reader, err := cli.ImagePull(ctx, i.Name, types.ImagePullOptions{}) //TODO format output
+	reader, err := cli.ImagePull(ctx, image.Name, types.ImagePullOptions{}) //TODO format output
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +75,7 @@ func (i *Image) Pull() (string, error) { //TODO remove splitting log streams her
 	return result, nil
 }
 
-func (i *Image) IsPulled() (bool, error) {
+func (image *Image) IsPulled() (bool, error) {
 	ctx, cli, err := clientAndContext()
 	if err != nil {
 		return false, err
@@ -87,7 +87,7 @@ func (i *Image) IsPulled() (bool, error) {
 	for _, s := range summaries {
 		for _, rt := range s.RepoTags {
 			logger.Debug().Msgf("repo tag: %s", rt)
-			if strings.HasSuffix(i.Name, rt) {
+			if strings.HasSuffix(image.Name, rt) {
 				return true, nil
 			}
 		}
@@ -104,8 +104,8 @@ type Job struct {
 	EnvironmentVariables map[string]string
 }
 
-func (j Job) Run() error {
-	return run(j)
+func (job Job) Run() error {
+	return run(job)
 }
 
 func run(job Job) error {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/docker/docker/api/types/mount"
@@ -101,8 +100,7 @@ type Job struct {
 	Command              string
 	Args                 []string
 	WorkDirectory        string
-	Mounts               []string
-	MountPath            string
+	Mounts               map[string]string
 	EnvironmentVariables map[string]string
 }
 
@@ -121,15 +119,16 @@ func run(job Job) error {
 	}
 	commandAndArgs := append([]string{job.Command}, job.Args...)
 	var mounts []mount.Mount
-	for _, m := range job.Mounts {
+	for k, v := range job.Mounts {
 		mounts = append(
 			mounts,
 			mount.Mount{
 				Type:   mount.TypeBind,
-				Source: path.Join(job.MountPath, m),
-				Target: m,
+				Source: v,
+				Target: k,
 			})
 	}
+	logger.Debug().Msgf("Job run mounts: %#v", mounts)
 
 	resp, err := cli.ContainerCreate(
 		ctx,

--- a/pkg/docker/ops.go
+++ b/pkg/docker/ops.go
@@ -2,7 +2,8 @@ package docker
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+	"os"
+	"time"
 )
 
 var (
@@ -10,9 +11,8 @@ var (
 )
 
 func init() {
-	logger = log.With().
-		Str("package", "docker").
-		Logger()
+	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	logger = zerolog.New(output).With().Str("package", "docker").Caller().Timestamp().Logger()
 }
 
 func debugJson(json []byte, format string, v ...interface{}) {

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -25,7 +25,7 @@ type InstalledComponentCommand struct {
 }
 
 //TODO add tests
-func (cc *InstalledComponentCommand) RunDocker(image string, workDirectory string, mountPath string, mounts []string) error {
+func (cc *InstalledComponentCommand) RunDocker(image string, workDirectory string, mountPath string, mounts []string, envsProcessor func(map[string]string) map[string]string) error {
 	for _, m := range mounts {
 		util.EnsureDirectory(path.Join(mountPath, m))
 	}
@@ -36,7 +36,7 @@ func (cc *InstalledComponentCommand) RunDocker(image string, workDirectory strin
 		WorkDirectory:        workDirectory,
 		Mounts:               mounts,
 		MountPath:            mountPath,
-		EnvironmentVariables: cc.Envs,
+		EnvironmentVariables: envsProcessor(cc.Envs),
 	}
 	debug("will try to run docker job %+v", dockerJob)
 	return dockerJob.Run()
@@ -60,7 +60,7 @@ type InstalledComponentVersion struct {
 }
 
 //TODO add tests
-func (cv *InstalledComponentVersion) Run(command string) error {
+func (cv *InstalledComponentVersion) Run(command string, envsProcessor func(map[string]string) map[string]string) error {
 	if cv.Type == "docker" {
 		mountPath := path.Join(
 			util.UsedEnvironmentDirectory,
@@ -71,7 +71,7 @@ func (cv *InstalledComponentVersion) Run(command string) error {
 		)
 		for _, cc := range cv.Commands {
 			if cc.Name == command {
-				return cc.RunDocker(cv.Image, cv.WorkDirectory, mountPath, cv.Mounts)
+				return cc.RunDocker(cv.Image, cv.WorkDirectory, mountPath, cv.Mounts, envsProcessor)
 			}
 		}
 	}

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -92,6 +92,14 @@ func (cv *InstalledComponentVersion) String() string {
 func (cv *InstalledComponentVersion) Download() error {
 	if cv.Type == "docker" {
 		dockerImage := &docker.Image{Name: cv.Image}
+		found, err := dockerImage.IsPulled()
+		if err != nil {
+			return err
+		}
+		if found {
+			logger.Debug().Msg("image is already present, no need to download") //TODO consider --force-download switch
+			return nil
+		}
 		logs, err := dockerImage.Pull()
 		cv.PersistLogs(logs)
 		if err != nil {

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -375,6 +375,7 @@ installed: []
 						Image:          "x",
 						WorkDirectory:  "x",
 						Mounts:         []string{"x"},
+						Shared:         "x",
 						Commands:       []InstalledComponentCommand{},
 					},
 				},
@@ -390,6 +391,7 @@ installed:
   workdir: x
   mounts:
   - x
+  shared: x
   commands: []
 `),
 			wantErr: nil,

--- a/pkg/environment/ops.go
+++ b/pkg/environment/ops.go
@@ -2,7 +2,8 @@ package environment
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+	"os"
+	"time"
 )
 
 var (
@@ -10,9 +11,8 @@ var (
 )
 
 func init() {
-	logger = log.With().
-		Str("package", "environment").
-		Logger()
+	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	logger = zerolog.New(output).With().Str("package", "environment").Caller().Timestamp().Logger()
 }
 
 func debug(format string, v ...interface{}) {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -3,7 +3,7 @@ package processor
 import (
 	"bytes"
 	"github.com/epiphany-platform/cli/pkg/configuration"
-	"github.com/epiphany-platform/cli/pkg/environment"
+	environments "github.com/epiphany-platform/cli/pkg/environment"
 	"github.com/rs/zerolog"
 	"os"
 	"strconv"
@@ -21,7 +21,7 @@ func init() {
 	logger = zerolog.New(output).With().Str("package", "processor").Caller().Timestamp().Logger()
 }
 
-func TemplateProcessor(c *configuration.Config, e *environment.Environment) func(s string) string {
+func TemplateProcessor(config *configuration.Config, environment *environments.Environment) func(s string) string {
 	return func(s string) string {
 		if strings.Contains(s, "#") {
 			parts := strings.Split(s, "#")
@@ -36,7 +36,7 @@ func TemplateProcessor(c *configuration.Config, e *environment.Environment) func
 					ii := i
 					next := i + 1
 					i++
-					r, err := process(strconv.Itoa(ii), parts[next], c)
+					r, err := process(strconv.Itoa(ii), parts[next], config)
 					if err != nil {
 						logger.Error().Err(err)
 						break
@@ -47,7 +47,7 @@ func TemplateProcessor(c *configuration.Config, e *environment.Environment) func
 					ii := i
 					next := i + 1
 					i++
-					r, err := process(strconv.Itoa(ii), parts[next], e)
+					r, err := process(strconv.Itoa(ii), parts[next], environment)
 					if err != nil {
 						logger.Error().Err(err)
 						break

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -1,0 +1,83 @@
+package processor
+
+import (
+	"bytes"
+	"github.com/epiphany-platform/cli/pkg/configuration"
+	"github.com/epiphany-platform/cli/pkg/environment"
+	"github.com/rs/zerolog"
+	"os"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+)
+
+var (
+	logger zerolog.Logger
+)
+
+func init() {
+	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	logger = zerolog.New(output).With().Str("package", "processor").Caller().Timestamp().Logger()
+}
+
+func TemplateProcessor(c *configuration.Config, e *environment.Environment) func(s string) string {
+	return func(s string) string {
+		if strings.Contains(s, "#") {
+			parts := strings.Split(s, "#")
+			logger.Debug().Msgf("and value has parts: %#v", parts)
+			if len(parts) < 2 {
+				return s
+			}
+			result := ""
+			for i := 0; i < len(parts); i++ {
+				switch p := parts[i]; p {
+				case "Config":
+					ii := i
+					next := i + 1
+					i++
+					r, err := process(strconv.Itoa(ii), parts[next], c)
+					if err != nil {
+						logger.Error().Err(err)
+						break
+					}
+					logger.Debug().Msgf("result value: %#v", r)
+					result = result + r
+				case "Environment":
+					ii := i
+					next := i + 1
+					i++
+					r, err := process(strconv.Itoa(ii), parts[next], e)
+					if err != nil {
+						logger.Error().Err(err)
+						break
+					}
+					logger.Debug().Msgf("result value: %#v", r)
+					result = result + r
+				default:
+					result = result + p
+				}
+			}
+			return result
+		}
+		return s
+	}
+}
+
+func process(name, pattern string, data interface{}) (string, error) {
+	t, err := template.New(name).Parse(pattern)
+	if err != nil {
+		logger.Error().Err(err)
+		return "", err
+	}
+	logger.Debug().Msgf("parsed template: %#v", t)
+	var b bytes.Buffer
+	err = t.Execute(&b, data)
+	if err != nil {
+		logger.Error().Err(err)
+		return "", err
+	}
+	r := b.String()
+	logger.Debug().Msgf("result value: %#v", r)
+	return r, nil
+}

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -65,7 +65,7 @@ func TemplateProcessor(c *configuration.Config, e *environment.Environment) func
 }
 
 func process(name, pattern string, data interface{}) (string, error) {
-	t, err := template.New(name).Parse(pattern)
+	t, err := template.New(name).Option("missingkey=error").Parse(pattern)
 	if err != nil {
 		logger.Error().Err(err)
 		return "", err

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1,0 +1,85 @@
+package processor
+
+import (
+	"testing"
+)
+
+func Test_process(t *testing.T) {
+	type data struct {
+		Field1 string
+		field2 string
+	}
+	type args struct {
+		name    string
+		pattern string
+		data    interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				name:    "hp",
+				pattern: "{{.Field1}}",
+				data: data{
+					Field1: "value1",
+					field2: "value2",
+				},
+			},
+			want:    "value1",
+			wantErr: false,
+		},
+		{
+			name: "unexported field",
+			args: args{
+				name:    "uf",
+				pattern: "{{.field2}}",
+				data: data{
+					Field1: "value1",
+					field2: "value2",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "empty pattern",
+			args: args{
+				name:    "ep",
+				pattern: "",
+				data: data{
+					Field1: "value1",
+					field2: "value2",
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "empty data",
+			args: args{
+				name:    "ed",
+				pattern: "{{.SomeField}}",
+				data:    nil,
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := process(tt.args.name, tt.args.pattern, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("process() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("process() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/repository/ops.go
+++ b/pkg/repository/ops.go
@@ -2,7 +2,8 @@ package repository
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+	"os"
+	"time"
 )
 
 var (
@@ -10,9 +11,8 @@ var (
 )
 
 func init() {
-	logger = log.With().
-		Str("package", "repository").
-		Logger()
+	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	logger = zerolog.New(output).With().Str("package", "repository").Caller().Timestamp().Logger()
 }
 
 func debug(format string, v ...interface{}) {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -33,6 +33,7 @@ type ComponentVersion struct {
 	Image         string             `yaml:"image"`
 	WorkDirectory string             `yaml:"workdir"`
 	Mounts        []string           `yaml:"mounts"`
+	Shared        string             `yaml:"shared"`
 	Commands      []ComponentCommand `yaml:"commands"`
 }
 

--- a/pkg/util/ops.go
+++ b/pkg/util/ops.go
@@ -2,7 +2,8 @@ package util
 
 import (
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+	"os"
+	"time"
 )
 
 var (
@@ -10,10 +11,8 @@ var (
 )
 
 func init() {
-	logger = log.
-		With().
-		Str("package", "util").
-		Logger()
+	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	logger = zerolog.New(output).With().Str("package", "util").Caller().Timestamp().Logger()
 }
 
 func debug(format string, v ...interface{}) {


### PR DESCRIPTION
Procedure to test this PR

* `./e cmp list` - it will initialise ~/.e/v1.yaml file. 
* If there is no azbi module entry please change content of that file with what is in [this PR](https://github.com/epiphany-platform/modules/pull/1) 
* `./e az sp create --name=my-test-1 --subscriptionID=xxx --tenantID=yyy --logLevel=debug` - it will create Service Provider to be passed do modules
* `./e env new --name=[some smart name]` - it will create new environment. Please notice that [default module configuration](https://github.com/epiphany-platform/modules/pull/1/files#diff-d46ec39e9ae9453a9354003d401a3cec0aa97a339ae927377bd9553dcfa72a9cR61) will use environment name as name suffix for infrastructure.
* `./e ssh keygen create --logLevel debug` - this will generate key pair in environment
* `./e cmp install azbi` - this will install AzBI module in environment
* `./e env run azbi init --logLevel=debug` - init
* `./e env run azbi plan --logLevel=debug` - plan
* `./e env run azbi apply --logLevel=debug` - apply
* `./e env run azbi plan-destroy --logLevel=debug` - plan destroy
* `./e env run azbi destroy --logLevel=debug` - destroy
